### PR TITLE
Improve headless execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# seat
+# Seat Assignment Utility
+
+This script assigns students to available seating and produces Excel and JSON
+reports. It can operate with a graphical interface when a display is
+available, or fall back to terminal prompts in headless environments.


### PR DESCRIPTION
## Summary
- handle `tkinter` errors by falling back to CLI prompts
- provide CLI `ask_yes_no` helper
- add basic project readme

## Testing
- `python -m py_compile seat.py`
- `python seat.py --help` *(fails due to EOF when reading a line)*

------
https://chatgpt.com/codex/tasks/task_e_6867bd2bc1d48320b70f1d68eb16a469